### PR TITLE
[ISSUE-1] Add web artifact release workflow

### DIFF
--- a/.github/workflows/web-artifact-release.yml
+++ b/.github/workflows/web-artifact-release.yml
@@ -1,0 +1,41 @@
+name: Web Artifact Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      source_tag:
+        description: "Current repository tag to build. Leave empty to use the latest v* tag."
+        required: false
+        default: ""
+        type: string
+
+concurrency:
+  group: web-artifact-release-${{ github.event.inputs.source_tag || 'latest' }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    permissions:
+      contents: write
+      packages: read
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+          cache: "npm"
+          cache-dependency-path: package-lock.json
+          registry-url: "https://npm.pkg.github.com"
+          scope: "@boudra"
+
+      - name: Build and publish web artifact release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          bash scripts/web-artifact-release/release.sh "${{ github.event.inputs.source_tag }}"

--- a/requirements/paseo_frontend_artifact_requirement.md
+++ b/requirements/paseo_frontend_artifact_requirement.md
@@ -1,0 +1,113 @@
+# Paseo 前端产物发布需求
+
+目标是在个人 fork `1996fanrui/paseo` 中发布 Paseo `v0.1.59` 的 web 前端构建产物。
+
+## 背景
+
+有外部系统需要固定消费 Paseo `v0.1.59` 的 web 前端 dist。官方仓库有 web 构建和部署流程，但没有可直接稳定下载的官方 web dist release asset。
+
+这个仓库只负责生成并发布 artifact，不负责下游系统如何下载、缓存或部署。
+
+## 决策
+
+使用个人 fork 的 GitHub Release asset，不把 dist 目录提交到源码分支。
+
+推荐 release tag：
+
+```text
+envtools-web-v0.1.59
+```
+
+原因：
+
+- 不复用 Paseo 正式版本 tag 名，避免把个人用途 artifact 和官方发版混在一起。
+- 后续升级时延续同一命名：`envtools-web-v0.1.60`、`envtools-web-v0.1.61`。
+- release asset 比把 dist 目录提交进源码分支更干净。
+
+## 目标产物
+
+在 `1996fanrui/paseo` 的 GitHub Release `envtools-web-v0.1.59` 上发布两个 asset：
+
+```text
+paseo-app-web-v0.1.59.tar.gz
+paseo-app-web-v0.1.59.sha256
+```
+
+tar 包解压后应直接得到前端 dist 内容，至少包含：
+
+```text
+index.html
+assets/
+```
+
+不要让 tar 包多包一层随机目录；解压后应直接能看到 `index.html`。
+
+## 执行方式
+
+这不是 Paseo 官方产品 release，不走 `npm run release:patch`，也不 bump 版本或发布 npm 包。
+
+仓库提供独立的 web artifact release 通道：
+
+- 先用 `bash scripts/web-artifact-release/create-source-tag.sh <source-tag> [ref]` 创建并推送 source tag；tag 必须手动输入，例如 `v0.1.59`，`ref` 不传时默认使用当前 commit。
+- GitHub Actions：手动触发 `Web Artifact Release` workflow。
+- `source_tag` 留空时，流程自动选择当前仓库最新的 `v*` tag；需要补发旧版本时，手动输入当前仓库已有 tag，例如 `v0.1.59`。
+- GitHub Actions 原生 `workflow_dispatch` 不支持动态读取仓库 tag 作为下拉选项；因此 `source_tag` 保持可选文本输入，流程会在运行时校验输入 tag 必须存在于当前仓库。
+- 实现位于 `scripts/web-artifact-release/`，其中 `README.md` 是日常使用入口，`release.sh` 是 workflow 调用的执行脚本。
+
+该流程会自动完成：
+
+- 从当前仓库 tag 中确定 source tag；
+- 确认 artifact tag `envtools-web-v0.1.59` 指向 source tag 对应 commit；
+- 确认构建 worktree 的 `HEAD` 与 source tag 一致；
+- 在临时 worktree 中安装依赖并构建 `packages/app/dist/`；
+- 打包并上传 release asset；
+- 下载 release asset，验证 sha256、`index.html` 和 `assets/`。
+
+## 关键命令
+
+GitHub Actions 执行：
+
+```bash
+gh workflow run web-artifact-release.yml \
+  --repo 1996fanrui/paseo \
+  -f source_tag=v0.1.59
+```
+
+不传 `source_tag` 时发布当前仓库最新 `v*` tag：
+
+```bash
+gh workflow run web-artifact-release.yml \
+  --repo 1996fanrui/paseo
+```
+
+## 验收
+
+完成后必须验证：
+
+```bash
+tmpdir="$(mktemp -d /tmp/agent-tmp/paseo-web-dist.XXXXXXXX)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+gh release download envtools-web-v0.1.59 \
+  --repo 1996fanrui/paseo \
+  --pattern 'paseo-app-web-v0.1.59.*' \
+  --dir "$tmpdir"
+
+cd "$tmpdir"
+sha256sum -c paseo-app-web-v0.1.59.sha256
+mkdir dist-check
+tar -xzf paseo-app-web-v0.1.59.tar.gz -C dist-check
+test -f dist-check/index.html
+test -d dist-check/assets
+```
+
+## 清理测试发布
+
+如果测试阶段发布的 release 有问题，可以删除 release 和 tag 后重新跑 workflow：
+
+```bash
+gh release delete envtools-web-v0.1.58 \
+  --repo 1996fanrui/paseo \
+  --cleanup-tag \
+  --yes
+```

--- a/scripts/web-artifact-release/README.md
+++ b/scripts/web-artifact-release/README.md
@@ -1,0 +1,70 @@
+# Web Artifact Release
+
+This directory publishes Paseo web frontend dist assets to the `1996fanrui/paseo` fork.
+
+This is not the official Paseo product release flow. It does not bump versions, publish npm packages, or deploy the app.
+
+## Create a Source Tag
+
+Create and push a source tag from the current commit:
+
+```bash
+bash scripts/web-artifact-release/create-source-tag.sh v0.1.59
+```
+
+To tag a branch or commit instead:
+
+```bash
+bash scripts/web-artifact-release/create-source-tag.sh v0.1.59 main
+```
+
+The tag name is always explicit.
+
+## Run from GitHub Actions
+
+Open GitHub Actions and run `Web Artifact Release`.
+
+Leave `source_tag` empty to build the latest current repository `v*` tag. To rebuild a specific version, enter a current repository tag such as:
+
+```text
+v0.1.59
+```
+
+The workflow will:
+
+- resolve the selected current repository tag;
+- verify the build checkout commit matches the selected tag;
+- create `envtools-web-v0.1.59` in `1996fanrui/paseo`;
+- upload `paseo-app-web-v0.1.59.tar.gz` and `paseo-app-web-v0.1.59.sha256`;
+- download the uploaded assets and verify sha256, `index.html`, and `assets/`.
+
+## Verify a Release
+
+```bash
+tmpdir="$(mktemp -d /tmp/agent-tmp/paseo-web-dist.XXXXXXXX)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+gh release download envtools-web-v0.1.59 \
+  --repo 1996fanrui/paseo \
+  --pattern 'paseo-app-web-v0.1.59.*' \
+  --dir "$tmpdir"
+
+cd "$tmpdir"
+sha256sum -c paseo-app-web-v0.1.59.sha256
+mkdir dist-check
+tar -xzf paseo-app-web-v0.1.59.tar.gz -C dist-check
+test -f dist-check/index.html
+test -d dist-check/assets
+du -sh dist-check
+```
+
+The `.tar.gz` file is compressed. For example, the `v0.1.58` asset was about 2 MB compressed and 8.3 MB after extraction.
+
+## Delete a Bad Test Release
+
+```bash
+gh release delete envtools-web-v0.1.59 \
+  --repo 1996fanrui/paseo \
+  --cleanup-tag \
+  --yes
+```

--- a/scripts/web-artifact-release/create-source-tag.sh
+++ b/scripts/web-artifact-release/create-source-tag.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+#
+# Create and push the source tag used by the web artifact release workflow.
+#
+# Usage:
+#   bash scripts/web-artifact-release/create-source-tag.sh v0.1.59
+#   bash scripts/web-artifact-release/create-source-tag.sh v0.1.59 main
+#   bash scripts/web-artifact-release/create-source-tag.sh v0.1.59 <commit-sha>
+#
+# The tag name must be provided explicitly. The target ref defaults to HEAD. This
+# script only creates and pushes the source tag; it does not build or upload the
+# web artifact.
+set -euo pipefail
+
+die() {
+  echo "error: $*" >&2
+  exit 1
+}
+
+remote_commit_for_tag() {
+  local tag="$1"
+
+  git ls-remote --tags origin "refs/tags/${tag}" "refs/tags/${tag}^{}" |
+    awk '$2 ~ /\^\{\}$/ { peeled=$1 } $2 !~ /\^\{\}$/ { direct=$1 } END { print peeled ? peeled : direct }'
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  awk '
+    /^set -euo pipefail$/ { exit }
+    /^#!/ { next }
+    /^#/ { sub(/^# ?/, ""); print }
+  ' "$0"
+  exit 0
+fi
+
+[[ $# -ge 1 ]] || die "source tag is required"
+[[ $# -le 2 ]] || die "usage: create-source-tag.sh <source-tag> [ref]"
+
+for command_name in git awk; do
+  command -v "$command_name" >/dev/null 2>&1 || die "$command_name is required"
+done
+
+SOURCE_TAG="$1"
+REF="${2:-HEAD}"
+SOURCE_COMMIT="$(git rev-parse --verify "${REF}^{commit}")"
+
+if git rev-parse -q --verify "refs/tags/${SOURCE_TAG}" >/dev/null; then
+  LOCAL_COMMIT="$(git rev-parse "refs/tags/${SOURCE_TAG}^{}")"
+  [[ "$LOCAL_COMMIT" == "$SOURCE_COMMIT" ]] || die "local ${SOURCE_TAG} points at ${LOCAL_COMMIT}, expected ${SOURCE_COMMIT}"
+else
+  git tag -a "$SOURCE_TAG" "$SOURCE_COMMIT" -m "$SOURCE_TAG"
+fi
+
+REMOTE_COMMIT="$(remote_commit_for_tag "$SOURCE_TAG")"
+if [[ -n "$REMOTE_COMMIT" ]]; then
+  [[ "$REMOTE_COMMIT" == "$SOURCE_COMMIT" ]] || die "remote ${SOURCE_TAG} points at ${REMOTE_COMMIT}, expected ${SOURCE_COMMIT}"
+  echo "Source tag ${SOURCE_TAG} already exists on origin at ${SOURCE_COMMIT}"
+else
+  git push origin "refs/tags/${SOURCE_TAG}:refs/tags/${SOURCE_TAG}"
+  echo "Pushed source tag ${SOURCE_TAG} for ${SOURCE_COMMIT}"
+fi

--- a/scripts/web-artifact-release/release.sh
+++ b/scripts/web-artifact-release/release.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+#
+# Build and publish the Paseo web frontend dist as a GitHub Release asset.
+#
+# Usage:
+#   bash scripts/web-artifact-release/release.sh
+#   bash scripts/web-artifact-release/release.sh v0.1.59
+#
+# This script is designed for GitHub Actions. It builds from a current repository
+# tag, creates a dedicated artifact tag that points at the same source commit,
+# uploads the web dist and its sha256 file, then downloads the assets back and
+# verifies them. When no source tag is provided, the latest v* tag is used.
+set -euo pipefail
+
+RELEASE_REPO="1996fanrui/paseo"
+RELEASE_REMOTE="origin"
+RELEASE_TAG_PREFIX="envtools-web"
+
+usage() {
+  awk '
+    /^set -euo pipefail$/ { exit }
+    /^#!/ { next }
+    /^#/ { sub(/^# ?/, ""); print }
+  ' "$0"
+}
+
+die() {
+  echo "error: $*" >&2
+  exit 1
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+[[ $# -le 1 ]] || die "at most one source tag is allowed"
+SOURCE_TAG="${1:-}"
+
+for command_name in git gh node npm tar sha256sum; do
+  command -v "$command_name" >/dev/null 2>&1 || die "$command_name is required"
+done
+
+mkdir -p /tmp/agent-tmp
+TMPDIR="$(mktemp -d /tmp/agent-tmp/paseo-web-artifact.XXXXXXXX)"
+WORKTREE="${TMPDIR}/worktree"
+DOWNLOAD_DIR="${TMPDIR}/download"
+
+cleanup() {
+  if [[ -d "$WORKTREE" ]]; then
+    git worktree remove --force "$WORKTREE" >/dev/null 2>&1 || true
+  fi
+  rm -rf "$TMPDIR"
+}
+trap cleanup EXIT
+
+remote_commit_for_tag() {
+  local remote="$1"
+  local tag="$2"
+
+  git ls-remote --tags "$remote" "refs/tags/${tag}" "refs/tags/${tag}^{}" |
+    awk '$2 ~ /\^\{\}$/ { peeled=$1 } $2 !~ /\^\{\}$/ { direct=$1 } END { print peeled ? peeled : direct }'
+}
+
+latest_source_tag() {
+  git tag --list 'v[0-9]*' --sort=-version:refname | head -n 1
+}
+
+if [[ -z "$SOURCE_TAG" ]]; then
+  SOURCE_TAG="$(latest_source_tag)"
+  [[ -n "$SOURCE_TAG" ]] || die "no v* source tags found in the current repository"
+  echo "No source tag provided; using latest current repository tag ${SOURCE_TAG}"
+fi
+
+git rev-parse -q --verify "refs/tags/${SOURCE_TAG}" >/dev/null || die "source tag ${SOURCE_TAG} was not found in the current repository"
+
+RELEASE_TAG="${RELEASE_TAG_PREFIX}-${SOURCE_TAG}"
+ASSET_BASENAME="paseo-app-web-${SOURCE_TAG}"
+TARBALL="${TMPDIR}/${ASSET_BASENAME}.tar.gz"
+SHA_FILE="${TMPDIR}/${ASSET_BASENAME}.sha256"
+SOURCE_COMMIT="$(git rev-parse "refs/tags/${SOURCE_TAG}^{}")"
+
+if git rev-parse -q --verify "refs/tags/${RELEASE_TAG}" >/dev/null; then
+  LOCAL_RELEASE_COMMIT="$(git rev-parse "${RELEASE_TAG}^{}")"
+  [[ "$LOCAL_RELEASE_COMMIT" == "$SOURCE_COMMIT" ]] || die "local ${RELEASE_TAG} points at ${LOCAL_RELEASE_COMMIT}, expected ${SOURCE_COMMIT}"
+else
+  git tag "$RELEASE_TAG" "$SOURCE_COMMIT"
+fi
+
+REMOTE_RELEASE_COMMIT="$(remote_commit_for_tag "$RELEASE_REMOTE" "$RELEASE_TAG")"
+if [[ -n "$REMOTE_RELEASE_COMMIT" ]]; then
+  [[ "$REMOTE_RELEASE_COMMIT" == "$SOURCE_COMMIT" ]] || die "remote ${RELEASE_TAG} points at ${REMOTE_RELEASE_COMMIT}, expected ${SOURCE_COMMIT}"
+else
+  git push "$RELEASE_REMOTE" "refs/tags/${RELEASE_TAG}:refs/tags/${RELEASE_TAG}"
+fi
+
+echo "Building web dist from ${SOURCE_TAG} (${SOURCE_COMMIT})"
+git worktree add --detach "$WORKTREE" "$SOURCE_COMMIT"
+(
+  cd "$WORKTREE"
+  WORKTREE_HEAD="$(git rev-parse HEAD)"
+  [[ "$WORKTREE_HEAD" == "$SOURCE_COMMIT" ]] || die "worktree HEAD ${WORKTREE_HEAD} does not match source commit ${SOURCE_COMMIT}"
+
+  echo "Verified ${SOURCE_TAG}: commit=${WORKTREE_HEAD}"
+  npm ci
+  npm run build:web --workspace=@getpaseo/app
+  test -f packages/app/dist/index.html
+  test -d packages/app/dist/assets
+)
+
+echo "Packaging ${ASSET_BASENAME}.tar.gz"
+(
+  cd "$WORKTREE/packages/app/dist"
+  tar -czf "$TARBALL" .
+)
+(
+  cd "$TMPDIR"
+  sha256sum "${ASSET_BASENAME}.tar.gz" > "${ASSET_BASENAME}.sha256"
+)
+
+if gh release view "$RELEASE_TAG" --repo "$RELEASE_REPO" >/dev/null 2>&1; then
+  gh release upload "$RELEASE_TAG" "$TARBALL" "$SHA_FILE" --repo "$RELEASE_REPO" --clobber
+else
+  gh release create "$RELEASE_TAG" "$TARBALL" "$SHA_FILE" \
+    --repo "$RELEASE_REPO" \
+    --title "Web dist for Paseo ${SOURCE_TAG}" \
+    --notes "Web frontend dist built from current repository tag ${SOURCE_TAG}."
+fi
+
+echo "Verifying uploaded release assets"
+mkdir -p "$DOWNLOAD_DIR"
+gh release download "$RELEASE_TAG" \
+  --repo "$RELEASE_REPO" \
+  --pattern "${ASSET_BASENAME}.*" \
+  --dir "$DOWNLOAD_DIR"
+(
+  cd "$DOWNLOAD_DIR"
+  sha256sum -c "${ASSET_BASENAME}.sha256"
+  mkdir dist-check
+  tar -xzf "${ASSET_BASENAME}.tar.gz" -C dist-check
+  test -f dist-check/index.html
+  test -d dist-check/assets
+)
+
+echo "Published ${RELEASE_TAG} to ${RELEASE_REPO}"


### PR DESCRIPTION
## Summary

- add a manual GitHub Actions workflow for publishing the app web dist as release assets
- build from current-repository source tags, with an empty input defaulting to the latest `v*` tag
- add a small source-tag helper script and documentation for creating, publishing, and verifying web artifacts

## Why

This fork needs a stable, downloadable web frontend artifact for downstream automation without running the full Paseo product release flow. Keeping the source tag lookup inside the current repository removes the upstream fetch dependency and makes the artifact release flow simpler to operate.

Closes #1

## Verification

- `bash -n scripts/web-artifact-release/release.sh`
- `bash -n scripts/web-artifact-release/create-source-tag.sh`
- `bash scripts/web-artifact-release/create-source-tag.sh --help`
- temporary-repository positive test for `create-source-tag.sh v1.2.3`
- temporary-repository negative test for mismatched source tag and package version
- `npm run lint`
- `git diff --check`

`npm run typecheck` is currently blocked by existing TypeScript errors outside this change, including Expo Router route type errors and existing `envMode` / provider type issues in desktop and CLI code.
