### PR TITLE
[ISSUE-3] Use current origin for web daemon bootstrap

### DIFF
--- a/packages/app/src/runtime/host-runtime.ts
+++ b/packages/app/src/runtime/host-runtime.ts
@@ -1075,7 +1075,15 @@ export class HostRuntimeController {
 }
 
 const REGISTRY_STORAGE_KEY = "@paseo:daemon-registry";
-const DEFAULT_LOCALHOST_ENDPOINT = process.env.EXPO_PUBLIC_LOCAL_DAEMON?.trim() || "localhost:6767";
+const browserLocation =
+  typeof globalThis.location === "object" ? globalThis.location : null;
+const DEFAULT_LOCALHOST_ENDPOINT =
+  process.env.EXPO_PUBLIC_LOCAL_DAEMON?.trim() ||
+  (browserLocation
+    ? `${browserLocation.hostname}:${
+        browserLocation.port || (browserLocation.protocol === "https:" ? "443" : "80")
+      }`
+    : "localhost:6767");
 const DEFAULT_LOCALHOST_BOOTSTRAP_KEY = "@paseo:default-localhost-bootstrap-v1";
 const DEFAULT_LOCALHOST_BOOTSTRAP_TIMEOUT_MS = 2500;
 const CONNECTION_ONLINE_TIMEOUT_MS = 15_000;


### PR DESCRIPTION
## Summary

- Use the current browser origin as the default local daemon endpoint when no explicit daemon endpoint is configured.
- Keep the change scoped to the v0.1.59-based maintenance branch for the custom web artifact.

## Verification

- npm run build:web --workspace=@getpaseo/app

Closes #3
